### PR TITLE
Using CURL as an alternative for https requests

### DIFF
--- a/src/Interfaces/ShortLinkAbstractInterface.php
+++ b/src/Interfaces/ShortLinkAbstractInterface.php
@@ -33,17 +33,6 @@ abstract class ShortLinkAbstractInterface
      */
     protected function request($url,$context)
     {
-        if (function_exists('curl_version')) {
-            $ch = curl_init();
-            curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-            curl_setopt($ch, CURLOPT_URL,$url);
-            $result = curl_exec($ch);
-            curl_close($ch);
-            return $result;
-        }
-        
         return file_get_contents($url,false,$context);
     }
 

--- a/src/Interfaces/ShortLinkAbstractInterface.php
+++ b/src/Interfaces/ShortLinkAbstractInterface.php
@@ -40,7 +40,7 @@ abstract class ShortLinkAbstractInterface
                     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $context["http"]["method"]);
                 }
                 if (array_key_exists("header", $context["http"])) {
-                    $delimiter = strpos("\r\n") === false ? "\n" : "\r\n";
+                    $delimiter = strpos($context["http"]["header"], "\r\n") === false ? "\n" : "\r\n";
                     $headers = array_filter(explode($delimiter, $context["http"]["header"]), function($item) {
                         return !is_null($item);
                     });

--- a/src/Interfaces/ShortLinkAbstractInterface.php
+++ b/src/Interfaces/ShortLinkAbstractInterface.php
@@ -33,6 +33,17 @@ abstract class ShortLinkAbstractInterface
      */
     protected function request($url,$context)
     {
+        if (function_exists('curl_version')) {
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_URL,$url);
+            $result = curl_exec($ch);
+            curl_close($ch);
+            return $result;
+        }
+        
         return file_get_contents($url,false,$context);
     }
 

--- a/src/Interfaces/ShortLinkAbstractInterface.php
+++ b/src/Interfaces/ShortLinkAbstractInterface.php
@@ -33,7 +33,32 @@ abstract class ShortLinkAbstractInterface
      */
     protected function request($url,$context)
     {
-        return file_get_contents($url,false,$context);
+        if (function_exists('curl_version')) {
+            $ch = curl_init();
+            if (array_key_exists("http", $context)) {
+                if (array_key_exists('method', $context["http"])) {
+                    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $context["http"]["method"]);
+                }
+                if (array_key_exists("header", $context["http"])) {
+                    $delimiter = strpos("\r\n") === false ? "\n" : "\r\n";
+                    $headers = array_filter(explode($delimiter, $context["http"]["header"]), function($item) {
+                        return !is_null($item);
+                    });
+                    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+                }
+                if (array_key_exists("content", $context["http"])) {
+                    curl_setopt($ch, CURLOPT_POSTFIELDS, $context["http"]["content"]);    
+                }
+            }
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_URL,$url);
+            $result = curl_exec($ch);
+            curl_close($ch);
+            return $result;
+        }
+
+        return file_get_contents($url,false,stream_context_create($context));
     }
 
 }

--- a/src/Shorty.php
+++ b/src/Shorty.php
@@ -44,6 +44,9 @@ class Shorty extends ShortLinkAbstractInterface
                                         "Content-Type: application/json\r\n",
                     'ignore_errors' => true,
                     'content'       => json_encode(array('longUrl' => $longUrl)),
+                ),
+                "ssl" => array(
+                    "verify_peer" => false
                 )
             );
 
@@ -69,7 +72,11 @@ class Shorty extends ShortLinkAbstractInterface
     {
         if ($this->urlCheck($shortUrl)) {
             $params = (!empty($this->apiKey)) ? '?'.implode('&',array($this->apiKey,"shortUrl={$shortUrl}")) : "?shortUrl={$shortUrl}";
-            $data = $this->request($this->api.$params,stream_context_create( array('http' => array('ignore_errors' => true) ) ) );
+            $streamContext = stream_context_create(array(
+                'http' => array('ignore_errors' => true),
+                "ssl" => array( "verify_peer" => false ) 
+            ) );
+            $data = $this->request($this->api.$params, $streamContext);
             $data = json_decode($data,true);
             $data = $this->validate($data,'expand');
 
@@ -89,7 +96,11 @@ class Shorty extends ShortLinkAbstractInterface
     {
         if ($this->urlCheck($shortUrl)) {
             $params = (!empty($this->apiKey)) ? '?'.implode('&',array($this->apiKey,"shortUrl={$shortUrl}","projection=FULL")) : implode('&',array("shortUrl={$shortUrl}","projection=FULL"));
-            $data = $this->request($this->api.$params,stream_context_create( array('http' => array('ignore_errors' => true) ) ));
+            $streamContext = stream_context_create(array(
+                'http' => array('ignore_errors' => true),
+                "ssl" => array( "verify_peer" => false ) 
+            ) );
+            $data = $this->request($this->api.$params,$streamContext);
             $data = json_decode($data,true);
             $data = $this->validate($data,'expand');
 

--- a/src/Shorty.php
+++ b/src/Shorty.php
@@ -51,7 +51,7 @@ class Shorty extends ShortLinkAbstractInterface
             );
 
             $params = (!empty($this->apiKey)) ? '?'.$this->apiKey : '';
-            $data = $this->request($this->api.$params, stream_context_create($request));
+            $data = $this->request($this->api.$params, $request);
             $data = json_decode($data,true);
             $data = $this->validate($data,'shorten');
 
@@ -72,10 +72,10 @@ class Shorty extends ShortLinkAbstractInterface
     {
         if ($this->urlCheck($shortUrl)) {
             $params = (!empty($this->apiKey)) ? '?'.implode('&',array($this->apiKey,"shortUrl={$shortUrl}")) : "?shortUrl={$shortUrl}";
-            $streamContext = stream_context_create(array(
+            $streamContext = array(
                 'http' => array('ignore_errors' => true),
                 "ssl" => array( "verify_peer" => false ) 
-            ) );
+            );
             $data = $this->request($this->api.$params, $streamContext);
             $data = json_decode($data,true);
             $data = $this->validate($data,'expand');
@@ -96,10 +96,10 @@ class Shorty extends ShortLinkAbstractInterface
     {
         if ($this->urlCheck($shortUrl)) {
             $params = (!empty($this->apiKey)) ? '?'.implode('&',array($this->apiKey,"shortUrl={$shortUrl}","projection=FULL")) : implode('&',array("shortUrl={$shortUrl}","projection=FULL"));
-            $streamContext = stream_context_create(array(
+            $streamContext = array(
                 'http' => array('ignore_errors' => true),
                 "ssl" => array( "verify_peer" => false ) 
-            ) );
+            );
             $data = $this->request($this->api.$params,$streamContext);
             $data = json_decode($data,true);
             $data = $this->validate($data,'expand');


### PR DESCRIPTION
Greetings,

I did some modifications on the Shorty class of your library, so we can use CURL as an alternative to make https requests.

I modified exactly these methods:
* `ShortLinkAbstractInterface::request`
* `Shorty::shorten($longUrl)`
* `Shorty::expand($shortUrl)`
* `Shorty::stats($shortUrl)`

Thanks for the nice library :)